### PR TITLE
Fix issue when command is one element in list (lxterminal affected).

### DIFF
--- a/eve-ng-integration
+++ b/eve-ng-integration
@@ -87,7 +87,7 @@ def main(argv):
 
         term.execute(cmd)
     elif url.scheme == 'telnet':
-        cmd = 'telnet {host} {port}'.format(**data)
+        cmd = ['telnet', '{host}'.format(**data), '{port}'.format(**data)]
 
         term.execute(cmd)
     else:


### PR DESCRIPTION
Hello.
One arg with 'command' not work with lxterminal, open lxtermianal without telnet session.

Not work:
```python
['lxterminal', '-e', 'telnet 192.168.0.214 32769']
```
Work as expected:
```python
['lxterminal', '-e', 'telnet', '192.168.0.214', '32769']
```
```shell
[k0ste@WorkStation ~]$ lxterminal --version
lxterminal 0.3.0
[k0ste@WorkStation ~]$ 
```

This patch make elements separated, should not be a regression with another terminal emulators. But you should check it.
Thanks.