### PR TITLE
Make the install.sh compatible with Fedora 29

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -106,9 +106,14 @@ for dist_id in $ID $ID_LIKE; do
 			do_install
 			;;
 		fedora)
+			if [ "${VERSION_ID}" -ge '29' ] ; then
+				wireshark_packagename='wireshark'
+			else
+				wireshark_packagename='wireshark-qt'
+			fi
 			_msg "Install dependencies..."
 			sudo dnf install -y ${PYTHON-"python"} \
-				openssh-askpass telnet vinagre wireshark-qt
+				openssh-askpass telnet vinagre "${wireshark_packagename}"
 			do_install
 			;;
 		opensuse|suse)


### PR DESCRIPTION
The wireshark package is renamed in Fedora 29 (they removed the -qt suffix). I've made the install.sh compatible with Fedora 29, without loosing the ability to install this package on Fedora 28 and older.