### PR TITLE
Wireshark: do not use SSH when Eve-NG is running on localhost

### DIFF
--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -75,13 +75,17 @@ def main(argv):
     }
 
     if url.scheme == 'capture':
-        cmd = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-              -l root {host} tcpdump -i {path} -n -s 0 -U -w -'.format(**data)
-        wireshark_cmd = 'wireshark -k -i -'
+        if data["host"] in ['127.0.0.1', 'localhost', '::1']:
+            wireshark_cmd = 'wireshark -k -i {path}'.format(**data)
+            Popen(wireshark_cmd.split())
+        else:
+            cmd = 'ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+                -l root {host} tcpdump -i {path} -n -s 0 -U -w -'.format(**data)
+            wireshark_cmd = 'wireshark -k -i -'
 
-        tcpdump = Popen(cmd.split(), stdout=PIPE, preexec_fn=os.setsid)
-        wireshark = Popen(wireshark_cmd.split(), stdin=tcpdump.stdout)
-        wireshark.communicate()
+            tcpdump = Popen(cmd.split(), stdout=PIPE, preexec_fn=os.setsid)
+            wireshark = Popen(wireshark_cmd.split(), stdin=tcpdump.stdout)
+            wireshark.communicate()
     elif url.scheme == 'docker':
         cmd = 'docker -H {host}:{port} attach {path}'.format(**data)
 

--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -75,7 +75,7 @@ def main(argv):
     }
 
     if url.scheme == 'capture':
-        if data["host"] in ['127.0.0.1', 'localhost', '::1']:
+        if data["host"] in ['127.0.0.1', 'localhost', '::1', '[::1]']:
             wireshark_cmd = 'wireshark -k -i {path}'.format(**data)
             Popen(wireshark_cmd.split())
         else:


### PR DESCRIPTION
It is sometime usefull to build a all-in-one bundled VM with Eve-NG and GUI for small and portable labs.

In that case, it is handy not to transport captured traffic over a local SSH tunnel but to directly ask Wireshark to listen to the local network interface.

This PR addresses that use case. 