### PR TITLE
Add support SwayWM with Foot terminal

### DIFF
--- a/bin/eve-ng-integration
+++ b/bin/eve-ng-integration
@@ -45,6 +45,8 @@ class Terminal(object):
             return ['pantheon-terminal', '-e']
         elif self._current_desktop('xfce'):
             return ['xfce4-terminal', '-e']
+        elif self._current_desktop('sway'):
+            return ['foot', 'sh', '-c']
         elif self._is_command('urxvt'):
             return ['urxvt', '-e']
         else:


### PR DESCRIPTION
Hello,

**Sway** is a tiling Wayland compositor and a drop-in replacement for the i3 window manager for X11. 
**Foot** is default terminal emulator for Sway (at least in the sway pkg in Arch).

Kind Regards,
Anton